### PR TITLE
Support later versions of starlette

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ homepage = "https://github.com/Woile/starlette-apispec"
 [tool.poetry.dependencies]
 python = "^3.6"
 apispec = "^0.39.0"
-starlette = "^0.8.8"
+starlette = ">=0.8.8"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.0"


### PR DESCRIPTION
I'm using this library with my project, but I had to roll my own wheel and distribute it manually to avoid potentially downgrading starlette to 0.8.8 while installing `starlette_apispec`.

Rather than just post an issue I thought I'd commit my changes and make a PR, in case my "fix" was palatable for others than myself.