### PR TITLE
fix: Fix support for apispec>=1.0.0b5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ Starlette APISpec
 .. code-block:: python
 
     from apispec import APISpec
+    from apispec.ext.marshmallow import MarshmallowPlugin
     from starlette.applications import Starlette
     from starlette_apispec import APISpecSchemaGenerator
 
@@ -36,7 +37,7 @@ Starlette APISpec
             version="1.0",
             openapi_version="3.0.0",
             info={"description": "explanation of the api purpose"},
-            plugins=["apispec.ext.marshmallow"],
+            plugins=[MarshmallowPlugin()],
         )
     )
 
@@ -64,18 +65,19 @@ which is ideal for building high performance asyncio services.
 `APISpec <https://apispec.readthedocs.io/en/stable/>`_ supports the `OpenApi Specification <https://github.com/OAI/OpenAPI-Specification>`_
 and it has some useful plugins like `marshmallow <https://marshmallow.readthedocs.io/en/3.0/>`_ support.
 
-Version supported: :code:`1.0.0b5`
+Version supported: :code:`>=1.0.0b5`
 
 
 Usage
 =====
 
 
-This example includes `marshmallow <https://marshmallow.readthedocs.io/en/3.0/>`_ integration
+This example includes `marshmallow <https://marshmallow.readthedocs.io/>`_ integration
 
 .. code-block:: python
 
     from apispec import APISpec
+    from apispec.ext.marshmallow import MarshmallowPlugin
 
     from marshmallow import Schema, fields
 
@@ -96,7 +98,7 @@ This example includes `marshmallow <https://marshmallow.readthedocs.io/en/3.0/>`
             version="1.0",
             openapi_version="3.0.0",
             info={"description": "explanation of the api purpose"},
-            plugins=["apispec.ext.marshmallow"],
+            plugins=[MarshmallowPlugin()],
         )
     )
     app.schema_generator.spec.definition("User", schema=UserSchema)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,9 @@ homepage = "https://github.com/Woile/starlette-apispec"
 
 [tool.poetry.dependencies]
 python = "^3.6"
+apispec = "^1.0.0b5"
 starlette = ">=0.8.8"
-apispec = { git = "https://github.com/marshmallow-code/apispec", tag = "1.0.0b5" }
+pyyaml = "^3.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.0"

--- a/tests/test_starlette_apispec.py
+++ b/tests/test_starlette_apispec.py
@@ -123,7 +123,7 @@ def test_schema_generation():
         },
         "tags": [],
         "openapi": "3.0.0",
-        "components": {"schemas": {}, 'responses': {}, "parameters": {}},
+        "components": {"schemas": {}, "responses": {}, "parameters": {}},
     }
 
 


### PR DESCRIPTION
* Pin to ``apispec^1.0.0b5``
* Add pyyaml as a dep, since it is no longer included
  with apispec
* Update documentation

close #1