### PR TITLE
fix: drop support for python deprecated versions and update packages

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,11 +28,3 @@ jobs:
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
         ./scripts/test
-    - name: Upload coverage to Codecov
-      if: runner.os == 'Linux'
-      uses: codecov/codecov-action@v1.0.3
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [tool.commitizen]
-version = "1.0.5"
 tag_format = "v$version"
+version_provider = "poetry"
 version_files = [
-  "pyproject.toml:version",
   "starlette_apispec/__init__.py:__version__"
 ]
 
@@ -48,19 +47,20 @@ license = "BSD-3-Clause"
 homepage = "https://github.com/Woile/starlette-apispec"
 
 [tool.poetry.dependencies]
-python = ">=3.6.1,<4.0"
+python = ">=3.8,<4.0"
 apispec = ">=1,<6"
 starlette = ">=0.11"
 pyyaml = ">=5.1,<7.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^6.0"
 flake8 = "^5.0"
-black = "^20.8b1"
-mypy = "^0.931"
+black = "^23.7.0"
+mypy = "^1.5"
 pytest-cov = "^3.0"
 codecov = "^2.0"
 isort = "^5.9.2"
+starlette = {version = "^0.31.0", extras = ["full"]}
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/scripts/test
+++ b/scripts/test
@@ -8,4 +8,5 @@ fi
 ${PREFIX}pytest --cov-report term-missing --cov-report=xml:coverage.xml --cov=starlette_apispec tests/
 ${PREFIX}black starlette_apispec tests --check
 ${PREFIX}isort --check-only starlette_apispec tests
+${PREFIX}mypy starlette_apispec/
 ${PREFIX}flake8 starlette_apispec/ tests/


### PR DESCRIPTION
BREAKING CHANGE: `py3.6` and `py3.7` have been dropped, please upgrade to `>=py3.8`

Closes #60